### PR TITLE
modify to allow better TSTL fuzzing

### DIFF
--- a/afl.pyx
+++ b/afl.pyx
@@ -77,10 +77,11 @@ cdef object trace
 def trace(frame, event, arg):
     global prev_location, tstl_mode
     cdef unsigned int location, offset
-    if tstl_mode and (os.path.basename(frame.f_code.co_filename).find("sut.py") == 0):
+    cdef object filename = frame.f_code.co_filename
+    if tstl_mode and (filename[-6:] == "sut.py"):
         return None
     location = (
-        lhash(frame.f_code.co_filename, frame.f_lineno)
+        lhash(filename, frame.f_lineno)
         % MAP_SIZE
     )
     offset = location ^ prev_location

--- a/afl.pyx
+++ b/afl.pyx
@@ -78,7 +78,7 @@ def trace(frame, event, arg):
     global prev_location, tstl_mode
     cdef unsigned int location, offset
     cdef object filename = frame.f_code.co_filename
-    if tstl_mode and (filename[-7:] in ['sut.py','/sut.py'):
+    if tstl_mode and (filename[-7:] in ['sut.py','/sut.py']):
         return None
     location = (
         lhash(filename, frame.f_lineno)

--- a/afl.pyx
+++ b/afl.pyx
@@ -77,8 +77,8 @@ cdef object trace
 def trace(frame, event, arg):
     global prev_location, tstl_mode
     cdef unsigned int location, offset
-    if tstl_mode and (frame.f_code.co_filename.find("sut.py") != -1):    
-       return trace
+    if tstl_mode and (os.path.basename(frame.f_code.co_filename).find("sut.py") == 0):
+        return None
     location = (
         lhash(frame.f_code.co_filename, frame.f_lineno)
         % MAP_SIZE
@@ -103,6 +103,7 @@ def excepthook(tp, value, traceback):
     os.kill(os.getpid(), except_signal_id)
 
 cdef bint init_done = False
+cdef bint tstl_mode = False
 
 cdef int _init(bint persistent_mode) except -1:
     global afl_area, init_done, tstl_mode

--- a/afl.pyx
+++ b/afl.pyx
@@ -78,7 +78,7 @@ def trace(frame, event, arg):
     global prev_location, tstl_mode
     cdef unsigned int location, offset
     cdef object filename = frame.f_code.co_filename
-    if tstl_mode and (filename[-6:] == "sut.py"):
+    if tstl_mode and (filename[-7:] in ['sut.py','/sut.py'):
         return None
     location = (
         lhash(filename, frame.f_lineno)

--- a/afl.pyx
+++ b/afl.pyx
@@ -75,8 +75,10 @@ def _hash(key, offset):
 
 cdef object trace
 def trace(frame, event, arg):
-    global prev_location
+    global prev_location, tstl_mode
     cdef unsigned int location, offset
+    if tstl_mode and (frame.f_code.co_filename.find("sut.py") != -1):    
+       return trace
     location = (
         lhash(frame.f_code.co_filename, frame.f_lineno)
         % MAP_SIZE
@@ -103,7 +105,8 @@ def excepthook(tp, value, traceback):
 cdef bint init_done = False
 
 cdef int _init(bint persistent_mode) except -1:
-    global afl_area, init_done
+    global afl_area, init_done, tstl_mode
+    tstl_mode = os.getenv('PYTHON_AFL_TSTL') is not None
     use_forkserver = True
     try:
         os.write(FORKSRV_FD + 1, b'\0\0\0\0')

--- a/afl.pyx
+++ b/afl.pyx
@@ -78,7 +78,7 @@ def trace(frame, event, arg):
     global prev_location, tstl_mode
     cdef unsigned int location, offset
     cdef object filename = frame.f_code.co_filename
-    if tstl_mode and (filename[-7:] in ['sut.py','/sut.py']):
+    if tstl_mode and (filename[-7:] in ['sut.py', '/sut.py']):
         return None
     location = (
         lhash(filename, frame.f_lineno)

--- a/doc/README
+++ b/doc/README
@@ -77,9 +77,11 @@ The following environment variables affect *python-afl* behavior:
    so there should normally no need to set it manually.
 
 ``PYTHON_AFL_TSTL``
-   [TSTL](https://github.com/agroce/tstl) test harness code is ignored
+   `TSTL`_ test harness code is ignored
    if this variable is set; relevant only to users of TSTL interface
-   to python-afl.  
+   to python-afl.
+
+.. _TSTL: https://github.com/agroce/tstl
 
 Further reading
 ---------------

--- a/doc/README
+++ b/doc/README
@@ -76,6 +76,9 @@ The following environment variables affect *python-afl* behavior:
    *py-afl-fuzz* sets this variable automatically,
    so there should normally no need to set it manually.
 
+ ``PYTHON_AFL_TSTL``
+   TSTL test harness code is ignored only if this variable is set.
+
 Further reading
 ---------------
 

--- a/doc/README
+++ b/doc/README
@@ -76,8 +76,10 @@ The following environment variables affect *python-afl* behavior:
    *py-afl-fuzz* sets this variable automatically,
    so there should normally no need to set it manually.
 
- ``PYTHON_AFL_TSTL``
-   TSTL test harness code is ignored only if this variable is set.
+``PYTHON_AFL_TSTL``
+   [TSTL](https://github.com/agroce/tstl) test harness code is ignored
+   if this variable is set; relevant only to users of TSTL interface
+   to python-afl.  
 
 Further reading
 ---------------


### PR DESCRIPTION
TSTL (https://github.com/agroce/tstl) is a property-based (unit) test generation tool that uses python-afl to allow afl to generate TSTL tests, which makes it possible to use afl to generate tests for complex properties, perform differential testing, and check well-defined execution determinism properties.

This change would allow an environment variable (PYTHON_AFL_TSTL) to be set causing the instrumentation to ignore code in the Python file sut.py, which contains the TSTL test harness, not actual code-under-test.  Sometimes it can be useful to include the harness code in the instrumentation, but usually not.
