### PR TITLE
[WIP] Expose trace map to Python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 matrix:
   include:
   - python: "2.6"
-    env: CYTHON=0.19
+    env: CYTHON=0.19.1
   - python: "2.7"
   - python: "3.2"
-    env: CYTHON=0.19
+    env: CYTHON=0.19.1
   - python: "3.3"
   - python: "3.4"
   - python: "3.5"

--- a/doc/README
+++ b/doc/README
@@ -102,7 +102,7 @@ Prerequisites
 To build the module, you will need:
 
 * Python 2.6+ or 3.2+
-* Cython ≥ 0.19 (only at build time)
+* Cython ≥ 0.19.1 (only at build time)
 
 *py-afl-fuzz* requires AFL proper to be installed.
 

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ meta = dict(
     author_email='jwilk@jwilk.net',
 )
 
-min_cython_version = '0.19'
+min_cython_version = '0.19.1'
 try:
     import Cython
 except ImportError:

--- a/tests/target_trace_map.py
+++ b/tests/target_trace_map.py
@@ -1,6 +1,6 @@
 # encoding=UTF-8
 
-# Copyright © 2015-2017 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2018 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal
@@ -20,38 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import sys
+
 import afl
 
-from .tools import (
-    assert_equal,
-)
+# pylint: disable=unsupported-assignment-operation
 
-exports = [
-    'init',
-    'loop',
-    'trace_map',
-]
+def main():
+    s = sys.stdin.read()
+    s.encode('ASCII')
+    for c in s:
+        afl.trace_map[ord(c)] += 1
 
-deprecated = [
-    'start',
-]
-
-def wildcard_import(mod):
-    ns = {}
-    exec('from {mod} import *'.format(mod=mod), {}, ns)
-    return ns
-
-def test_wildcard_import():
-    ns = wildcard_import('afl')
-    assert_equal(
-        sorted(ns.keys()),
-        sorted(exports)
-    )
-
-def test_dir():
-    assert_equal(
-        sorted(o for o in dir(afl) if not o.startswith('_')),
-        sorted(exports + deprecated)
-    )
+if __name__ == '__main__':
+    afl.init()
+    main()
 
 # vim:ts=4 sts=4 sw=4 et

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -169,6 +169,8 @@ def test_fuzz(dumb=False):
                 )
     yield t, 'target.py'
     yield t, 'target_persistent.py'
+    if not dumb:
+        yield t, 'target_trace_map.py'
 
 def test_fuzz_dumb():
     if get_afl_version() < '1.95':


### PR DESCRIPTION
This allows Python code to manually poke at the trace map, which might be useful for blackbox testing.
Possible alternative to #9.

Before this gets merged:

- [ ] Document the new feature.
- [ ] Discuss addition of a similar API to afl-clang-fast on [afl-users](https://groups.google.com/forum/#!forum/afl-users).*

<sup>* Last time I innovated with new API, AFL proper adapted it under a different (better!) name, and then I had to rename mine… Let's not make this mistake again.</sup>