### PR TITLE
WIP: Opcode tracing

### DIFF
--- a/tests/target.py
+++ b/tests/target.py
@@ -31,7 +31,7 @@ def main():
         print('Hum?')
         sys.exit(1)
     s.encode('ASCII')
-    if s[0] == '0':
+    if s[0] == '0' or s[0] == '\0' or s == 'zero' or s == "zero\n":
         print('Looks like a zero to me!')
     else:
         print('A non-zero value? How quaint!')

--- a/tests/target_persistent.py
+++ b/tests/target_persistent.py
@@ -32,7 +32,7 @@ def main():
         print('Hum?')
         sys.exit(1)
     s.encode('ASCII')
-    if s[0] == '0':
+    if s[0] == '0' or s[0] == '\0' or s == 'zero' or s == "zero\n":
         print('Looks like a zero to me!')
     else:
         print('A non-zero value? How quaint!')


### PR DESCRIPTION
Implemented opcode tracing.

This version updates hash until we do something else. So my tests/target.py generates different maps. Without this feature same ops generate just increased count and I felt it was not enough.

You can test this with suite of: '0' '\0' 'zero' 'zero\n' and compare
```
py-afl-showmap -o out -i in -- python tests/target.py
```

This is tested with python 3.9 and afl-fuzz++ 3.00a. You need separate patch to support afl-fuzz++.

I tries to implement https://github.com/jwilk/python-afl/issues/15

